### PR TITLE
Use threading to fetch Garlond data, static window ID

### DIFF
--- a/ItemVendorLocation/Plugin.cs
+++ b/ItemVendorLocation/Plugin.cs
@@ -11,6 +11,7 @@ using Dalamud.Game.Text.SeStringHandling.Payloads;
 using System;
 using System.Linq;
 using XivCommon.Functions.Tooltips;
+using System.Threading.Tasks;
 
 namespace ItemVendorLocation
 {
@@ -493,16 +494,18 @@ namespace ItemVendorLocation
 
         private void HandleItem(Lumina.Excel.GeneratedSheets.Item item)
         {
-            ulong garlondToolsId = FindGarlondToolsItemId(item);
-            List<Models.Vendor> vendors = GetVendors(garlondToolsId);
-            if (Configuration.ShowAllVendorsBool)
-            {
-                DisplayOneVendor(item, vendors.Last());
-            }
-            else
-            {
-                DisplayAllVendors(item, vendors);
-            }
+            Task.Run(() => {
+                ulong garlondToolsId = FindGarlondToolsItemId(item);
+                List<Models.Vendor> vendors = GetVendors(garlondToolsId);
+                if (Configuration.ShowAllVendorsBool)
+                {
+                    DisplayOneVendor(item, vendors.Last());
+                }
+                else
+                {
+                    DisplayAllVendors(item, vendors);
+                }
+            });
         }
 
         public void Dispose()

--- a/ItemVendorLocation/PluginUI.cs
+++ b/ItemVendorLocation/PluginUI.cs
@@ -95,7 +95,7 @@ namespace ItemVendorLocation
 
             ImGui.SetNextWindowSize(new Vector2(375, 200), ImGuiCond.FirstUseEver);
             ImGui.SetNextWindowSizeConstraints(new Vector2(375, 200), new Vector2(float.MaxValue, float.MaxValue));
-            if (ImGui.Begin($"{ItemName} Vendors", ref vendorLocationsVisable))
+            if (ImGui.Begin($"{ItemName} Vendors###Item Vendor Location", ref vendorLocationsVisable))
             {
                 if (ImGui.BeginTable("Vendors", 4, ImGuiTableFlags.Resizable))
                 {


### PR DESCRIPTION
Use threading to fetch Garlond data to avoid the game freezing for a split second.
Make the vendors list window use a static ID to keep window settings between items.