### PR TITLE
Add Collectable shops and some relic weapons

### DIFF
--- a/ItemVendorLocation/EntryPoint.cs
+++ b/ItemVendorLocation/EntryPoint.cs
@@ -365,6 +365,7 @@ namespace ItemVendorLocation
         {
             Service.PluginUi.SetItemToDisplay(item);
             Service.PluginUi.IsOpen = true;
+            Service.PluginUi.Collapsed = false;
         }
 
         private static void ShowSingleVendor(ItemInfo item)

--- a/ItemVendorLocation/EntryPoint.cs
+++ b/ItemVendorLocation/EntryPoint.cs
@@ -21,6 +21,7 @@ using GrandCompany = FFXIVClientStructs.FFXIV.Client.UI.Agent.GrandCompany;
 using AgentInterface = FFXIVClientStructs.FFXIV.Component.GUI.AgentInterface;
 using System.Threading.Tasks;
 using Dalamud.Game.ClientState.Keys;
+using ImGuiNET;
 
 namespace ItemVendorLocation
 {
@@ -366,6 +367,7 @@ namespace ItemVendorLocation
             Service.PluginUi.SetItemToDisplay(item);
             Service.PluginUi.IsOpen = true;
             Service.PluginUi.Collapsed = false;
+            Service.PluginUi.CollapsedCondition = ImGuiCond.Once;
         }
 
         private static void ShowSingleVendor(ItemInfo item)


### PR DESCRIPTION
Also fix an issue that location window isn't shown in some cases (this should work)

During this, I found that some items, like ``Newborn Soulstone(16932)``, can only be obtained from quests. Parsing ``Quest.csv`` to get quest rewards could be a good idea, however, plugin ``Quest Map`` already does something similar, so I wonder if I should add this to plugin or just let the user use wiki/other plugins to know where/how to get the item