### PR TITLE
Avoid exception for items with no shop selling price tooltip line

### DIFF
--- a/ItemVendorLocation/EntryPoint.cs
+++ b/ItemVendorLocation/EntryPoint.cs
@@ -320,7 +320,11 @@ namespace ItemVendorLocation
                     itemtooltip[ItemTooltipString.ShopSellingPrice] = string.Concat(origStr.TextValue.AsSpan(0, origStr.TextValue.IndexOfAny(new[] { '：', ':' })), "：", costStr);
                     return;
                 case ItemType.SpecialShop:
-                    itemtooltip[ItemTooltipString.ShopSellingPrice] = string.Concat(origStr.TextValue.AsSpan(0, origStr.TextValue.IndexOfAny(new[] { '：', ':' })), "：Special Vendor");
+                    var pos = origStr.TextValue.IndexOfAny(new[] { '：', ':' });
+                    // Avoid modification for certain seasonal items with no Shop Selling Price line
+                    if (pos != -1) {
+                        itemtooltip[ItemTooltipString.ShopSellingPrice] = string.Concat(origStr.TextValue.AsSpan(0, pos), "：Special Vendor");
+                    }
                     return;
                 case ItemType.FcShop:
                     info = itemInfo.NpcInfos.First();


### PR DESCRIPTION
For certain seasonal miscellany items (e.g. confetti), even though the addon knows of a vendor, the tooltip lacks a "Shop Selling Price" line, which causes an exception to be logged when we assume `IndexOfAny` returns a valid index (for these items, `origStr` is an empty string).

We could actually force these items to show the Shop Selling Price line by setting `itemtooltip.Fields |= ItemTooltipFields.Unknown19` (this flag seemingly controls the shop selling price visibility) but at that point we'd need to set the entire string, which I wasn't so sure about.

This change simply avoids the logged exception by skipping tooltip modification if the colon is missing.