### PR TITLE
Add error handling for Chat2

### DIFF
--- a/ItemVendorLocation/Ipc.cs
+++ b/ItemVendorLocation/Ipc.cs
@@ -4,6 +4,8 @@ using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin;
 
+//https://git.anna.lgbt/anna/ChatTwo/src/branch/main/ipc.md
+
 namespace ItemVendorLocation;
 
 internal class Ipc
@@ -50,7 +52,8 @@ internal class Ipc
     private void RegisterIpc()
     {
         // Register and save the registration ID.
-        _id = Register.InvokeFunc();
+        try { _id = Register.InvokeFunc(); }
+        catch (Dalamud.Plugin.Ipc.Exceptions.IpcNotReadyError) { Service.PluginLog.Debug("Chat2 is not available"); }
     }
 
     public void Disable()


### PR DESCRIPTION
Not sure if there is a better way to do this, but this fixed my issue.

I'd be curious to see if you have a similar issue. To reproduce, I disabled chat2, then could disable and reenable vendor location.