### PR TITLE
Adds item/menu selection highlights

### DIFF
--- a/ItemVendorLocation/EntryPoint.cs
+++ b/ItemVendorLocation/EntryPoint.cs
@@ -297,6 +297,7 @@ public class EntryPoint : IDalamudPlugin
         Service.VendorResultsUi.IsOpen = true;
         Service.VendorResultsUi.Collapsed = false;
         Service.VendorResultsUi.CollapsedCondition = ImGuiCond.Once;
+        Service.HighlightObject.SetNpcInfo([.. item.NpcInfos]);
     }
 
     private static void ShowSingleVendor(ItemInfo item)
@@ -323,7 +324,7 @@ public class EntryPoint : IDalamudPlugin
         _ = sb.AddText(" at ");
         _ = sb.Append(SeString.CreateMapLink(vendor.Location.TerritoryType, vendor.Location.MapId, vendor.Location.MapX, vendor.Location.MapY));
         Utilities.OutputChatLine(sb.BuiltString);
-        Service.HighlightObject.SetNpcInfo(vendor);
+        Service.HighlightObject.SetNpcInfo([vendor]);
     }
 
     private static void ResultDisplayHandler(ItemInfo item)

--- a/ItemVendorLocation/EntryPoint.cs
+++ b/ItemVendorLocation/EntryPoint.cs
@@ -54,6 +54,7 @@ public class EntryPoint : IDalamudPlugin
 
         _xivCommon = new();
         Service.HighlightObject = new();
+        Service.HighlightMenus = new();
 
         // Initialize the UI
         _windowSystem = new(typeof(EntryPoint).AssemblyQualifiedName);
@@ -298,6 +299,7 @@ public class EntryPoint : IDalamudPlugin
         Service.VendorResultsUi.Collapsed = false;
         Service.VendorResultsUi.CollapsedCondition = ImGuiCond.Once;
         Service.HighlightObject.SetNpcInfo([.. item.NpcInfos]);
+        Service.HighlightMenus.SetNpcInfo([.. item.NpcInfos]);
     }
 
     private static void ShowSingleVendor(ItemInfo item)
@@ -325,6 +327,7 @@ public class EntryPoint : IDalamudPlugin
         _ = sb.Append(SeString.CreateMapLink(vendor.Location.TerritoryType, vendor.Location.MapId, vendor.Location.MapX, vendor.Location.MapY));
         Utilities.OutputChatLine(sb.BuiltString);
         Service.HighlightObject.SetNpcInfo([vendor]);
+        Service.HighlightMenus.SetNpcInfo([vendor]);
     }
 
     private static void ResultDisplayHandler(ItemInfo item)
@@ -360,6 +363,7 @@ public class EntryPoint : IDalamudPlugin
         Service.ChatTwoIpc.Disable();
         Service.ItemVendorLocationIpc.Dispose();
         Service.HighlightObject.Dispose();
+        Service.HighlightMenus.Dispose();
 
         _ = Service.CommandManager.RemoveHandler(_commandName);
         _xivCommon.Functions.Tooltips.OnItemTooltip -= Tooltips_OnOnItemTooltip;

--- a/ItemVendorLocation/EntryPoint.cs
+++ b/ItemVendorLocation/EntryPoint.cs
@@ -300,6 +300,7 @@ public class EntryPoint : IDalamudPlugin
         Service.VendorResultsUi.CollapsedCondition = ImGuiCond.Once;
         Service.HighlightObject.SetNpcInfo([.. item.NpcInfos]);
         Service.HighlightMenus.SetNpcInfo([.. item.NpcInfos]);
+        Service.HighlightMenus.SetItemName(item.Name);
     }
 
     private static void ShowSingleVendor(ItemInfo item)
@@ -328,6 +329,7 @@ public class EntryPoint : IDalamudPlugin
         Utilities.OutputChatLine(sb.BuiltString);
         Service.HighlightObject.SetNpcInfo([vendor]);
         Service.HighlightMenus.SetNpcInfo([vendor]);
+        Service.HighlightMenus.SetItemName(item.Name);
     }
 
     private static void ResultDisplayHandler(ItemInfo item)

--- a/ItemVendorLocation/EntryPoint.cs
+++ b/ItemVendorLocation/EntryPoint.cs
@@ -327,8 +327,8 @@ public class EntryPoint : IDalamudPlugin
         _ = sb.AddText(" at ");
         _ = sb.Append(SeString.CreateMapLink(vendor.Location.TerritoryType, vendor.Location.MapId, vendor.Location.MapX, vendor.Location.MapY));
         Utilities.OutputChatLine(sb.BuiltString);
-        Service.HighlightObject.SetNpcInfo([vendor]);
-        Service.HighlightMenus.SetNpcInfo([vendor]);
+        Service.HighlightObject.SetNpcInfo([.. item.NpcInfos]);
+        Service.HighlightMenus.SetNpcInfo([.. item.NpcInfos]);
         Service.HighlightMenus.SetItemName(item.Name);
     }
 

--- a/ItemVendorLocation/GUI/SettingsWindow.cs
+++ b/ItemVendorLocation/GUI/SettingsWindow.cs
@@ -6,6 +6,7 @@ using Dalamud.Interface.Components;
 using Lumina.Excel.Sheets;
 using System.Linq;
 using Dalamud.Game.ClientState.Keys;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
 
 namespace ItemVendorLocation.GUI;
 
@@ -83,7 +84,17 @@ public class SettingsWindow : Window
             Service.Configuration.Save();
         }
         ImGui.SameLine();
-        ImGuiComponents.HelpMarker(@"If checked, will highlight the selected npc in red once it is in object list");
+        ImGuiComponents.HelpMarker(@"If checked, will highlight npcs that sell last item searched for once they are visible on-screen");
+        ImGui.SameLine();
+        var highlightColorNames = Enum.GetNames<ObjectHighlightColor>();
+        var highlightColorValues = Enum.GetValues<ObjectHighlightColor>();
+        var selectedHighlightColor = Array.IndexOf(highlightColorValues, Service.Configuration.HighlightColor);
+        ImGui.SetNextItemWidth(150f);
+        if (ImGui.Combo("Highlight Color", ref selectedHighlightColor, highlightColorNames, highlightColorNames.Length))
+        {
+            Service.Configuration.HighlightColor = (ObjectHighlightColor)selectedHighlightColor;
+            Service.Configuration.Save();
+        }
 
         ImGui.SetNextItemWidth(200f);
         int maxSearchResults = Service.Configuration.MaxSearchResults;

--- a/ItemVendorLocation/GUI/SettingsWindow.cs
+++ b/ItemVendorLocation/GUI/SettingsWindow.cs
@@ -105,7 +105,12 @@ public class SettingsWindow : Window
             Service.Configuration.Save();
         }
         ImGui.SameLine();
-        ImGuiComponents.HelpMarker(@"If checked, will highlight menu selections so items are easier to find.");
+        ImGuiComponents.HelpMarker(@"If checked, will highlight menu selections so items are easier to find.
+
+NOTE: If you search for another item that is sold by a vendor whose menu you already have open, this
+will cause both the previous item and the new item to be highlighted. I could fix this, but the only way I
+know how is to redraw every non-highlighted item with the original color. The highlighting occurs every
+frame, and I'm not willing to add another loop per frame for this use case which I think is stupid.");
         ImGui.SameLine();
         // this part seems dumb to me, but it works
         var selectedShopHighlightColor = Service.Configuration.ShopHighlightColor;

--- a/ItemVendorLocation/GUI/SettingsWindow.cs
+++ b/ItemVendorLocation/GUI/SettingsWindow.cs
@@ -7,6 +7,8 @@ using Lumina.Excel.Sheets;
 using System.Linq;
 using Dalamud.Game.ClientState.Keys;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using Dalamud.Interface.Style;
+using Dalamud.Interface.Colors;
 
 namespace ItemVendorLocation.GUI;
 
@@ -93,6 +95,25 @@ public class SettingsWindow : Window
         if (ImGui.Combo("Highlight Color", ref selectedHighlightColor, highlightColorNames, highlightColorNames.Length))
         {
             Service.Configuration.HighlightColor = (ObjectHighlightColor)selectedHighlightColor;
+            Service.Configuration.Save();
+        }
+
+        var highlightMenuSelections = Service.Configuration.HighlightMenuSelections;
+        if (ImGui.Checkbox("Highlight menu selections", ref highlightMenuSelections))
+        {
+            Service.Configuration.HighlightMenuSelections = highlightMenuSelections;
+            Service.Configuration.Save();
+        }
+        ImGui.SameLine();
+        ImGuiComponents.HelpMarker(@"If checked, will highlight menu selections so items are easier to find.");
+        ImGui.SameLine();
+        // this part seems dumb to me, but it works
+        var selectedShopHighlightColor = Service.Configuration.ShopHighlightColor;
+        ImGui.SetNextItemWidth(150f);
+        selectedShopHighlightColor = ImGuiComponents.ColorPickerWithPalette(1, "Highlight Color", selectedShopHighlightColor, ImGuiColorEditFlags.NoAlpha);
+        if (selectedShopHighlightColor != Service.Configuration.ShopHighlightColor)
+        {
+            Service.Configuration.ShopHighlightColor = selectedShopHighlightColor;
             Service.Configuration.Save();
         }
 

--- a/ItemVendorLocation/GUI/VendorResultsWindow.cs
+++ b/ItemVendorLocation/GUI/VendorResultsWindow.cs
@@ -57,7 +57,7 @@ public class VendorResultsWindow : Window
                 // need to use an ID here, the armorer/blacksmith vendors have the same location, resulting in a problem otherwise
                 if (ImGui.Button($"{placeString}###{npcInfo.Id}"))
                 {
-                    Service.HighlightObject.SetNpcInfo(npcInfo);
+                    Service.HighlightObject.SetNpcInfo([npcInfo]);
                     _ = Service.GameGui.OpenMapWithMapLink(new(location.TerritoryType, location.MapId, location.MapX, location.MapY, 0f));
                 }
 

--- a/ItemVendorLocation/HighlightMenus.cs
+++ b/ItemVendorLocation/HighlightMenus.cs
@@ -31,6 +31,7 @@ internal class HighlightMenus : IDisposable
         HighlightSelectIconStringAddon();
         HighlightSelectStringAddon();
         HighlightInclusionShopAddon();
+        HighlightShopExchangeCurrencyAddon();
     }
 
     private unsafe void HighlightShopAddon()
@@ -212,6 +213,50 @@ internal class HighlightMenus : IDisposable
                 continue;
             }
             var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(5);
+            if (text == null)
+            {
+                continue;
+            }
+            var itemName = SeString.Parse(text->GetText()).TextValue;
+            if (itemName == _itemName)
+            {
+                text->TextColor = Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(Service.Configuration.ShopHighlightColor);
+                // strangely, it doesn't seem like the list gets its color updated until we set the text below
+                text->SetText(SeString.Parse(text->GetText()).TextValue);
+            }
+        }
+    }
+
+    private unsafe void HighlightShopExchangeCurrencyAddon()
+    {
+        var shopExchangeCurrencyAddonPtr = Service.GameGui.GetAddonByName("ShopExchangeCurrency");
+
+        if (shopExchangeCurrencyAddonPtr == nint.Zero)
+        {
+            return;
+        }
+
+        var shopExchangeCurrencyAddon = (AtkUnitBase*)shopExchangeCurrencyAddonPtr;
+
+        var itemList = (AtkComponentTreeList*)shopExchangeCurrencyAddon->GetComponentByNodeId(19);
+
+        if (itemList == null)
+        {
+            return;
+        }
+
+        foreach (var item in itemList->Items)
+        {
+            var listItemRenderer = item.Value->Renderer;
+            if (listItemRenderer == null)
+            {
+                continue;
+            }
+            var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(3);
+            if (text == null)
+            {
+                text = (AtkTextNode*)listItemRenderer->GetTextNodeById(8);
+            }
             if (text == null)
             {
                 continue;

--- a/ItemVendorLocation/HighlightMenus.cs
+++ b/ItemVendorLocation/HighlightMenus.cs
@@ -1,0 +1,91 @@
+﻿using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Interface.Colors;
+using Dalamud.Plugin.Services;
+using Dalamud.Utility;
+using FFXIVClientStructs.FFXIV.Client.Graphics;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using ItemVendorLocation.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Unicode;
+using System.Threading.Tasks;
+
+namespace ItemVendorLocation;
+internal class HighlightMenus : IDisposable
+{
+    private NpcInfo[] _npcInfo = [];
+    private uint[] _targetNpcDataId = [];
+
+    public HighlightMenus()
+    {
+        Service.Framework.Update += Framework_OnUpdate;
+    }
+
+    private unsafe void Framework_OnUpdate(IFramework framework)
+    {
+        HighlightShopAddon();
+        HighlightSelectIconStringAddon();
+    }
+
+    private unsafe void HighlightShopAddon()
+    {
+        var shopAddonPtr = Service.GameGui.GetAddonByName("Shop");
+        if (shopAddonPtr == nint.Zero)
+        {
+            return;
+        }
+
+        var shopAddon = (AtkUnitBase*)shopAddonPtr;
+    }
+
+    private unsafe void HighlightSelectIconStringAddon()
+    {
+        var selectIconStringAddonPtr = Service.GameGui.GetAddonByName("SelectIconString");
+
+        if (selectIconStringAddonPtr == nint.Zero)
+        {
+            return;
+        }
+
+        var selectIconStringAddon = (AtkUnitBase*)selectIconStringAddonPtr;
+
+        var componentList = selectIconStringAddon->GetComponentListById(3);
+
+        if (componentList == null)
+        {
+            return;
+        }
+
+        foreach (uint index in Enumerable.Range(0, componentList->ListLength))
+        {
+            var listItemRenderer = componentList->ItemRendererList[index].AtkComponentListItemRenderer;
+            if (listItemRenderer == null)
+            {
+                continue;
+            }
+            var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(2);
+            if (text == null)
+            {
+                continue;
+            }
+            if (_npcInfo.Any(n => n.ShopName.Contains(SeString.Parse(text->GetText()).TextValue)))
+            {
+                text->TextColor = Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(Service.Configuration.ShopHighlightColor);
+            }
+        }
+    }
+
+    public void SetNpcInfo(NpcInfo[] npcInfos)
+    {
+        _npcInfo = npcInfos;
+    }
+
+    public void Dispose()
+    {
+        Service.Framework.Update -= Framework_OnUpdate;
+    }
+}

--- a/ItemVendorLocation/HighlightMenus.cs
+++ b/ItemVendorLocation/HighlightMenus.cs
@@ -32,6 +32,7 @@ internal class HighlightMenus : IDisposable
         HighlightSelectStringAddon();
         HighlightInclusionShopAddon();
         HighlightShopExchangeCurrencyAddon();
+        HighlightShopExchangeItem();
     }
 
     private unsafe void HighlightShopAddon()
@@ -257,6 +258,46 @@ internal class HighlightMenus : IDisposable
             {
                 text = (AtkTextNode*)listItemRenderer->GetTextNodeById(8);
             }
+            if (text == null)
+            {
+                continue;
+            }
+            var itemName = SeString.Parse(text->GetText()).TextValue;
+            if (itemName == _itemName)
+            {
+                text->TextColor = Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(Service.Configuration.ShopHighlightColor);
+                // strangely, it doesn't seem like the list gets its color updated until we set the text below
+                text->SetText(SeString.Parse(text->GetText()).TextValue);
+            }
+        }
+    }
+
+    private unsafe void HighlightShopExchangeItem()
+    {
+        var shopExchangeItemAddonPtr = Service.GameGui.GetAddonByName("ShopExchangeItem");
+
+        if (shopExchangeItemAddonPtr == nint.Zero)
+        {
+            return;
+        }
+
+        var shopExchangeItemAddon = (AtkUnitBase*)shopExchangeItemAddonPtr;
+
+        var itemList = (AtkComponentTreeList*)shopExchangeItemAddon->GetComponentByNodeId(19);
+
+        if (itemList == null)
+        {
+            return;
+        }
+
+        foreach (var item in itemList->Items)
+        {
+            var listItemRenderer = item.Value->Renderer;
+            if (listItemRenderer == null)
+            {
+                continue;
+            }
+            var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(7);
             if (text == null)
             {
                 continue;

--- a/ItemVendorLocation/HighlightMenus.cs
+++ b/ItemVendorLocation/HighlightMenus.cs
@@ -18,7 +18,7 @@ namespace ItemVendorLocation;
 internal class HighlightMenus : IDisposable
 {
     private NpcInfo[] _npcInfo = [];
-    private uint[] _targetNpcDataId = [];
+    private string _itemName = string.Empty;
 
     public HighlightMenus()
     {
@@ -29,6 +29,7 @@ internal class HighlightMenus : IDisposable
     {
         HighlightShopAddon();
         HighlightSelectIconStringAddon();
+        HighlightInclusionShopAddon();
     }
 
     private unsafe void HighlightShopAddon()
@@ -79,9 +80,97 @@ internal class HighlightMenus : IDisposable
         }
     }
 
+    private unsafe void HighlightInclusionShopAddon()
+    {
+        var inclusionShopAddonPtr = Service.GameGui.GetAddonByName("InclusionShop");
+
+        if (inclusionShopAddonPtr == nint.Zero)
+        {
+            return;
+        }
+
+        var inclusionShopAddon = (AtkUnitBase*)inclusionShopAddonPtr;
+
+        var category = (AtkComponentDropDownList*)inclusionShopAddon->GetComponentByNodeId(7);
+        var subcategory = (AtkComponentDropDownList*)inclusionShopAddon->GetComponentByNodeId(9);
+        var itemList = (AtkComponentTreeList*)inclusionShopAddon->GetComponentByNodeId(19);
+
+        if (category == null || subcategory == null)
+        {
+            return;
+        }
+        foreach (uint index in Enumerable.Range(0, category->List->ListLength))
+        {
+            var listItemRenderer = category->List->ItemRendererList[index].AtkComponentListItemRenderer;
+            if (listItemRenderer == null)
+            {
+                continue;
+            }
+            var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(4);
+            if (text == null)
+            {
+                continue;
+            }
+            var textValue = SeString.Parse(text->GetText()).TextValue;
+            if (!string.IsNullOrEmpty(textValue) && _npcInfo.Any(n => n.ShopName.Contains(textValue)))
+            {
+                text->TextColor = Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(Service.Configuration.ShopHighlightColor);
+            }
+        }
+        foreach (uint index in Enumerable.Range(0, subcategory->List->ListLength))
+        {
+            var listItemRenderer = subcategory->List->ItemRendererList[index].AtkComponentListItemRenderer;
+            if (listItemRenderer == null)
+            {
+                continue;
+            }
+            var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(4);
+            if (text == null)
+            {
+                continue;
+            }
+            var textValue = SeString.Parse(text->GetText()).TextValue;
+            if (!string.IsNullOrEmpty(textValue) && _npcInfo.Any(n => n.ShopName.Contains(textValue)))
+            {
+                text->TextColor = Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(Service.Configuration.ShopHighlightColor);
+            }
+        }
+
+        if (itemList == null)
+        {
+            return;
+        }
+
+        foreach (var item in itemList->Items)
+        {
+            var listItemRenderer = item.Value->Renderer;
+            if (listItemRenderer == null)
+            {
+                continue;
+            }
+            var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(5);
+            if (text == null)
+            {
+                continue;
+            }
+            var itemName = SeString.Parse(text->GetText()).TextValue;
+            if (itemName == _itemName)
+            {
+                text->TextColor = Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(Service.Configuration.ShopHighlightColor);
+                // strangely, it doesn't seem like the list gets its color updated until we set the text below
+                text->SetText(SeString.Parse(text->GetText()).TextValue);
+            }
+        }
+    }
+
     public void SetNpcInfo(NpcInfo[] npcInfos)
     {
         _npcInfo = npcInfos;
+    }
+
+    public void SetItemName(string itemName)
+    {
+        _itemName = itemName;
     }
 
     public void Dispose()

--- a/ItemVendorLocation/HighlightMenus.cs
+++ b/ItemVendorLocation/HighlightMenus.cs
@@ -29,6 +29,7 @@ internal class HighlightMenus : IDisposable
     {
         HighlightShopAddon();
         HighlightSelectIconStringAddon();
+        HighlightSelectStringAddon();
         HighlightInclusionShopAddon();
     }
 
@@ -70,6 +71,43 @@ internal class HighlightMenus : IDisposable
     private unsafe void HighlightSelectIconStringAddon()
     {
         var selectIconStringAddonPtr = Service.GameGui.GetAddonByName("SelectIconString");
+
+        if (selectIconStringAddonPtr == nint.Zero)
+        {
+            return;
+        }
+
+        var selectIconStringAddon = (AtkUnitBase*)selectIconStringAddonPtr;
+
+        var componentList = selectIconStringAddon->GetComponentListById(3);
+
+        if (componentList == null)
+        {
+            return;
+        }
+
+        foreach (uint index in Enumerable.Range(0, componentList->ListLength))
+        {
+            var listItemRenderer = componentList->ItemRendererList[index].AtkComponentListItemRenderer;
+            if (listItemRenderer == null)
+            {
+                continue;
+            }
+            var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(2);
+            if (text == null)
+            {
+                continue;
+            }
+            if (_npcInfo.Any(n => n.ShopName.Contains(SeString.Parse(text->GetText()).TextValue)))
+            {
+                text->TextColor = Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(Service.Configuration.ShopHighlightColor);
+            }
+        }
+    }
+
+    private unsafe void HighlightSelectStringAddon()
+    {
+        var selectIconStringAddonPtr = Service.GameGui.GetAddonByName("SelectString");
 
         if (selectIconStringAddonPtr == nint.Zero)
         {

--- a/ItemVendorLocation/HighlightMenus.cs
+++ b/ItemVendorLocation/HighlightMenus.cs
@@ -41,6 +41,30 @@ internal class HighlightMenus : IDisposable
         }
 
         var shopAddon = (AtkUnitBase*)shopAddonPtr;
+
+        var itemList = (AtkComponentList*)shopAddon->GetComponentByNodeId(16);
+
+        foreach (uint index in Enumerable.Range(0, itemList->ListLength))
+        {
+            var listItemRenderer = itemList->ItemRendererList[index].AtkComponentListItemRenderer;
+
+            if (listItemRenderer == null)
+            {
+                continue;
+            }
+            var text = (AtkTextNode*)listItemRenderer->GetTextNodeById(3);
+            if (text == null)
+            {
+                continue;
+            }
+            var itemName = SeString.Parse(text->GetText()).TextValue;
+            if (itemName == _itemName)
+            {
+                text->TextColor = Dalamud.Utility.Numerics.VectorExtensions.ToByteColor(Service.Configuration.ShopHighlightColor);
+                // strangely, it doesn't seem like the list gets its color updated until we set the text below
+                text->SetText(SeString.Parse(text->GetText()).TextValue);
+            }
+        }
     }
 
     private unsafe void HighlightSelectIconStringAddon()
@@ -99,6 +123,7 @@ internal class HighlightMenus : IDisposable
         {
             return;
         }
+
         foreach (uint index in Enumerable.Range(0, category->List->ListLength))
         {
             var listItemRenderer = category->List->ItemRendererList[index].AtkComponentListItemRenderer;

--- a/ItemVendorLocation/HighlightObject.cs
+++ b/ItemVendorLocation/HighlightObject.cs
@@ -16,7 +16,6 @@ internal class HighlightObject : IDisposable
 
     public HighlightObject()
     {
-        Service.ClientState.TerritoryChanged += ClientState_OnTerritoryChanged;
         Service.Framework.Update += Framework_OnUpdate;
     }
 
@@ -36,22 +35,6 @@ internal class HighlightObject : IDisposable
         }
 
         ToggleHighlight(true);
-    }
-
-    private void ClientState_OnTerritoryChanged(ushort territoryId)
-    {
-        if (_npcInfo == null)
-        {
-            return;
-        }
-
-        if (_npcInfo.Any(n => n.Location.TerritoryType == territoryId))
-        {
-            return;
-        }
-
-        _npcInfo = [];
-        _targetNpcDataId = [];
     }
 
     public void SetNpcInfo(NpcInfo[] npcInfos)
@@ -101,7 +84,6 @@ internal class HighlightObject : IDisposable
 
     public void Dispose()
     {
-        Service.ClientState.TerritoryChanged -= ClientState_OnTerritoryChanged;
         Service.Framework.Update -= Framework_OnUpdate;
     }
 }

--- a/ItemVendorLocation/HighlightObject.cs
+++ b/ItemVendorLocation/HighlightObject.cs
@@ -80,23 +80,23 @@ internal class HighlightObject : IDisposable
             return;
         }
 
-        var gameObject = Service.ObjectTable.FirstOrDefault(i =>
+        var gameObjects = Service.ObjectTable.Where(i =>
         {
             if (!i.IsValid())
                 return false;
             var obj = (GameObject*)i.Address;
-            var found = _targetNpcDataId.Contains(obj->BaseId);
-            return found;
+            return _targetNpcDataId.Contains(obj->BaseId);
         });
 
-        if (gameObject == null)
+        if (!gameObjects.Any())
         {
             return;
         }
 
-        Service.PluginLog.Debug("Setting highlight color");
-
-        ((GameObject*)gameObject.Address)->Highlight(on ? Service.Configuration.HighlightColor : ObjectHighlightColor.None);
+        foreach (var obj in gameObjects)
+        {
+            ((GameObject*)obj.Address)->Highlight(on ? Service.Configuration.HighlightColor : ObjectHighlightColor.None);
+        }
     }
 
     public void Dispose()

--- a/ItemVendorLocation/ItemLookup.AddItem.cs
+++ b/ItemVendorLocation/ItemLookup.AddItem.cs
@@ -14,7 +14,7 @@ public partial class ItemLookup
 public partial class ItemLookup
 #endif
 {
-    private void AddSpecialItem(SpecialShop specialShop, ENpcBase npcBase, ENpcResident resident, ItemType type = ItemType.SpecialShop, string shop = null)
+    private void AddSpecialItem(SpecialShop specialShop, ENpcBase npcBase, ENpcResident resident, ItemType type = ItemType.SpecialShop, string? shop = null)
     {
         foreach (var entry in specialShop.Item)
         {
@@ -212,7 +212,8 @@ public partial class ItemLookup
             if (MatchEventHandlerType(data, EventHandlerType.SpecialShop))
             {
                 var specialShop = _specialShops.GetRow(data);
-                AddSpecialItem(specialShop, npcBase, resident, shop: topicSelect.Name.ExtractText());
+                
+                AddSpecialItem(specialShop, npcBase, resident, shop: $"{topicSelect.Name.ExtractText()}\n{specialShop.Name.ExtractText()}");
 
                 continue;
             }
@@ -406,7 +407,7 @@ public partial class ItemLookup
         result.Costs.AddRange(cost);
     }
 
-    private void AddItem_Internal(uint itemId, string itemName, uint npcId, string npcName, string shopName, List<Tuple<uint, string>> cost, NpcLocation npcLocation,
+    private void AddItem_Internal(uint itemId, string itemName, uint npcId, string npcName, string? shopName, List<Tuple<uint, string>> cost, NpcLocation npcLocation,
                                   ItemType type,
                                   string achievementDesc = "")
     {

--- a/ItemVendorLocation/PluginConfiguration.cs
+++ b/ItemVendorLocation/PluginConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Configuration;
 using Dalamud.Game.ClientState.Keys;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using System;
 
 namespace ItemVendorLocation;
@@ -16,7 +17,8 @@ public class PluginConfiguration : IPluginConfiguration
     public bool FilterDuplicates { get; set; } = true;
     public bool ShowShopName { get; set; } = false;
     public ushort MaxSearchResults { get; set; } = 5;
-    public bool HighlightSelectedNpc { get; set; } = false;
+    public bool HighlightSelectedNpc { get; set; } = true;
+    public ObjectHighlightColor HighlightColor { get; set; } = ObjectHighlightColor.Red;
     public VirtualKey SearchDisplayModifier { get; set; } = VirtualKey.NO_KEY;
 #if DEBUG
     public int BuildDebugVendorInfo { get; set; } = 0;

--- a/ItemVendorLocation/PluginConfiguration.cs
+++ b/ItemVendorLocation/PluginConfiguration.cs
@@ -1,7 +1,9 @@
 ﻿using Dalamud.Configuration;
 using Dalamud.Game.ClientState.Keys;
+using Dalamud.Interface.Colors;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using System;
+using System.Numerics;
 
 namespace ItemVendorLocation;
 
@@ -19,6 +21,8 @@ public class PluginConfiguration : IPluginConfiguration
     public ushort MaxSearchResults { get; set; } = 5;
     public bool HighlightSelectedNpc { get; set; } = true;
     public ObjectHighlightColor HighlightColor { get; set; } = ObjectHighlightColor.Red;
+    public bool HighlightMenuSelections { get; set; } = true;
+    public Vector4 ShopHighlightColor { get; set; } = ImGuiColors.DalamudRed;
     public VirtualKey SearchDisplayModifier { get; set; } = VirtualKey.NO_KEY;
 #if DEBUG
     public int BuildDebugVendorInfo { get; set; } = 0;

--- a/ItemVendorLocation/Service.cs
+++ b/ItemVendorLocation/Service.cs
@@ -17,6 +17,7 @@ internal class Service
     internal static ChatTwoIPC ChatTwoIpc { get; set; } = null!;
     internal static ItemVendorLocationIpc ItemVendorLocationIpc{ get; set; } = null!;
     internal static HighlightObject HighlightObject { get; set; } = null!;
+    internal static HighlightMenus HighlightMenus { get; set; } = null!;
 
 
     [PluginService] public static IChatGui ChatGui { get; set; } = null!;


### PR DESCRIPTION
Adds some config options to highlight items/menus.

Also tweaks NPC highlighting mainly to support multiple vendors, but also removes the clearing of npc info on territory change. This way if you teleport to an NPC you are searching for, they will still be highlighted.