### PR TITLE
fix null exception in GetItemVendors IPC when the vendor has no location

### DIFF
--- a/ItemVendorLocation/IPC/ItemVendorLocation.cs
+++ b/ItemVendorLocation/IPC/ItemVendorLocation.cs
@@ -51,8 +51,15 @@ public class ItemVendorLocationIpc : IDisposable
 
         foreach (var npcInfo in itemInfo.NpcInfos)
         {
-            var location = npcInfo.Location;
-            vendors.Add((npcInfo.Id, location.TerritoryType, (location.MapX, location.MapX)));
+            if (npcInfo.Location != null)
+            {
+                var location = npcInfo.Location;
+                vendors.Add((npcInfo.Id, location.TerritoryType, (location.MapX, location.MapX)));
+            }
+            else if(!Service.Configuration.FilterNPCsWithNoLocation)
+            {
+                vendors.Add((npcInfo.Id, 0, (0, 0)));
+            }
         }
 
         return vendors;


### PR DESCRIPTION
Hi,
I was trying the IPC when I found that it was crashing on https://github.com/electr0sheep/ItemVendorLocation/blob/f23354ee1996f1b69cf7828fcd83f82dbe2f8b44/ItemVendorLocation/IPC/ItemVendorLocation.cs#L54 as the `NpcInfo.Location` can actually be null.

I also made it so it's aware of `FilterNPCsWithNoLocation` config and filters out the NPCs without locations.

I decided to return the location id 0 which does not exist, and the x,y as 0,0. Not sure it's a completely good idea but on on the moment it felt right.