### PR TITLE
Fix: Remove InclusionShop.Unknown0 for Dalamud API 15 / Patch 7.5

### DIFF
--- a/ItemVendorLocation/ItemLookup.AddItem.cs
+++ b/ItemVendorLocation/ItemLookup.AddItem.cs
@@ -114,12 +114,8 @@ public partial class ItemLookup
                     }
 
                     var specialShop = series.Value.SpecialShop.Value;
-                    var shop = "";
-                    if (!string.IsNullOrEmpty(inclusionShop.Unknown0.ExtractText()))
-                    {
-                        shop += $"{inclusionShop.Unknown0.ExtractText()}\n";
-                    }
-                    shop += $"{category.Value.Name}\n{specialShop.Name}";
+                    
+                    var shop = $"{category.Value.Name}\n{specialShop.Name}";
                     AddSpecialItem(specialShop, npcBase, resident, shop: shop);
                 }
                 catch (Exception)


### PR DESCRIPTION
Fix: Remove InclusionShop.Unknown0 for Dalamud API 15 / Patch 7.5 InclusionShop.Unknown0 was removed/renamed in Lumina with FFXIV Patch 7.5. This caused 2 compile errors (CS1061) blocking the build under Dalamud API 15. The field was an optional shop name prefix — removing it restores the same behaviour as earlier versions of the plugin.